### PR TITLE
2598 wizard fauxton same origin

### DIFF
--- a/src/setup.erl
+++ b/src/setup.erl
@@ -47,7 +47,7 @@ is_cluster_enabled() ->
 
 cluster_system_dbs() ->
     ["_users", "_replicator", "_metadata", "_global_changes"].
-        
+
 
 has_cluster_system_dbs() ->
     has_cluster_system_dbs(cluster_system_dbs()).

--- a/src/setup.erl
+++ b/src/setup.erl
@@ -99,7 +99,7 @@ enable_cluster_http(Options) ->
         {ok, "201", _, _} ->
             ok;
         Else ->
-            io:format("~nsend_req: ~p~n", [Else]),
+            couch_log:notice("send_req: ~p~n", [Else]),
             {error, Else}
     end.
 
@@ -141,7 +141,7 @@ enable_cluster_int(Options, no) ->
         Port ->
             config:set("httpd", "port", integer_to_list(Port))
     end,
-    io:format("~nEnable Cluster: ~p~n", [Options]).
+    couch_log:notice("Enable Cluster: ~p~n", [Options]).
     %cluster_state:set(enabled).
 
 maybe_set_admin(Username, Password) ->
@@ -168,7 +168,7 @@ add_node(Options) ->
 add_node_int(_Options, no) ->
     {error, cluster_not_enabled};
 add_node_int(Options, ok) ->
-    io:format("~nadd node: ~p~n", [Options]),
+    couch_log:notice("add node: ~p~n", [Options]),
     ErlangCookie = erlang:get_cookie(),
 
     % POST to nodeB/_setup
@@ -198,7 +198,7 @@ add_node_int(Options, ok) ->
             % when done, PUT :5986/nodes/nodeB
             create_node_doc(Host, Port);
         Else ->
-            io:format("~nsend_req: ~p~n", [Else]),
+            couch_log:notice("send_req: ~p~n", [Else]),
             Else
     end.
 

--- a/src/setup_httpd.erl
+++ b/src/setup_httpd.erl
@@ -55,7 +55,10 @@ handle_action("enable_cluster", Setup) ->
         {username, <<"username">>},
         {password, <<"password">>},
         {bind_address, <<"bind_address">>},
-        {port, <<"port">>}
+        {port, <<"port">>},
+        {remote_node, <<"remote_node">>},
+        {remote_current_user, <<"remote_current_user">>},
+        {remote_current_password, <<"remote_current_password">>}
     ], Setup),
     case setup:enable_cluster(Options) of
         {error, cluster_enabled} ->

--- a/src/setup_httpd.erl
+++ b/src/setup_httpd.erl
@@ -19,7 +19,7 @@ handle_setup_req(#httpd{method='POST'}=Req) ->
     ok = chttpd:verify_is_server_admin(Req),
     couch_httpd:validate_ctype(Req, "application/json"),
     Setup = get_body(Req),
-    io:format("~nSetup: ~p~n", [Setup]),
+    couch_log:notice("Setup: ~p~n", [Setup]),
     Action = binary_to_list(couch_util:get_value(<<"action">>, Setup, <<"missing">>)),
     case handle_action(Action, Setup) of
     ok ->
@@ -68,17 +68,17 @@ handle_action("enable_cluster", Setup) ->
 
 
 handle_action("finish_cluster", Setup) ->
-    io:format("~nffinish_cluster: ~p~n", [Setup]),
+    couch_log:notice("finish_cluster: ~p~n", [Setup]),
     case setup:finish_cluster() of
         {error, cluster_finished} ->
             {error, <<"Cluster is already finished">>};
         Else ->
-            io:format("~nElse: ~p~n", [Else]),
+            couch_log:notice("Else: ~p~n", [Else]),
             ok
     end;
 
 handle_action("add_node", Setup) ->
-    io:format("~nadd_node: ~p~n", [Setup]),
+    couch_log:notice("add_node: ~p~n", [Setup]),
 
     Options = get_options([
         {username, <<"username">>},
@@ -99,10 +99,10 @@ handle_action("add_node", Setup) ->
     end;
 
 handle_action("remove_node", Setup) ->
-    io:format("~nremove_node: ~p~n", [Setup]);
+    couch_log:notice("remove_node: ~p~n", [Setup]);
 
 handle_action("receive_cookie", Setup) ->
-    io:format("~nreceive_cookie: ~p~n", [Setup]),
+    couch_log:notice("receive_cookie: ~p~n", [Setup]),
     Options = get_options([
        {cookie, <<"cookie">>}
     ], Setup),
@@ -113,7 +113,7 @@ handle_action("receive_cookie", Setup) ->
     end;
 
 handle_action(_, _) ->
-    io:format("~ninvalid_action: ~n", []),
+    couch_log:notice("invalid_action: ~n", []),
     {error, <<"Invalid Action'">>}.
 
 
@@ -122,6 +122,6 @@ get_body(Req) ->
     {Body} ->
         Body;
     Else ->
-        io:format("~nBody Fail: ~p~n", [Else]),
+        couch_log:notice("Body Fail: ~p~n", [Else]),
         couch_httpd:send_error(Req, 400, <<"bad_request">>, <<"Missing JSON body'">>)
     end.

--- a/test/t-frontend-setup.sh
+++ b/test/t-frontend-setup.sh
@@ -1,0 +1,60 @@
+#!/bin/sh -ex
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+HEADERS="-HContent-Type:application/json"
+# show cluster state:
+curl a:b@127.0.0.1:15986/_nodes/_all_docs
+
+# Enable Cluster on node A
+curl a:b@127.0.0.1:15984/_cluster_setup -d '{"action":"enable_cluster","username":"foo","password":"baz","bind_address":"0.0.0.0"}' $HEADERS
+
+# Enable Cluster on node B
+curl a:b@127.0.0.1:15984/_cluster_setup -d '{"action":"enable_cluster","remote_node":"127.0.0.1","port":"25984","remote_current_user":"a","remote_current_password":"b","username":"foo","password":"baz","bind_address":"0.0.0.0"}' $HEADERS
+
+# Add node B on node A
+curl a:b@127.0.0.1:15984/_cluster_setup -d '{"action":"add_node","username":"foo","password":"baz","host":"127.0.0.1","port":25984}' $HEADERS
+
+# Show cluster state:
+curl a:b@127.0.0.1:15986/_nodes/_all_docs
+
+# Show db doesn’t exist on node A
+curl a:b@127.0.0.1:15984/foo
+
+# Show db doesn’t exist on node B
+curl a:b@127.0.0.1:25984/foo
+
+# Create database (on node A)
+curl -X PUT a:b@127.0.0.1:15984/foo
+
+# Show db does exist on node A
+curl a:b@127.0.0.1:15984/foo
+
+# Show db does exist on node B
+curl a:b@127.0.0.1:25984/foo
+
+# Finish cluster
+curl a:b@127.0.0.1:15984/_cluster_setup -d '{"action":"finish_cluster"}' $HEADERS
+
+# Show system dbs exist on node A
+curl a:b@127.0.0.1:15984/_users
+curl a:b@127.0.0.1:15984/_replicator
+curl a:b@127.0.0.1:15984/_metadata
+curl a:b@127.0.0.1:15984/_global_changes
+
+# Show system dbs exist on node B
+curl a:b@127.0.0.1:25984/_users
+curl a:b@127.0.0.1:25984/_replicator
+curl a:b@127.0.0.1:25984/_metadata
+curl a:b@127.0.0.1:25984/_global_changes
+
+echo "YAY ALL GOOD"


### PR DESCRIPTION
this feature makes it easier to setup a cluster for browser
applications like fauxton as browsers follow the same-origin
policy. Before this PR you had to open the wizard in Fauxton on
all three nodes and enter your data there, which was quite
confusing and hard to explain. Now you can stay in the same tab
at the same address.

This PR enables three new params in the body:

`remote_node`:

ip of the remote node where we want to send the `enable_cluster`
request

`remote_current_user`:

the current admin username of the remote node

`remote_current_password`:

the current admin password of the remote node

To test, I run:

```
rm -rf dev/lib/ && ./dev/run --no-join --admin=a:b
```

and then run the test script:

```
./src/setup/t-frontend-setup.sh
```

COUCHDB-2598
