### PR TITLE
require nodecount on setup

### DIFF
--- a/src/setup.erl
+++ b/src/setup.erl
@@ -142,7 +142,7 @@ enable_cluster_int(Options, no) ->
 
     NodeCount = couch_util:get_value(node_count, Options),
     ok = require_clustersize(NodeCount),
-    config:set("cluster", "n", integer_to_list(NodeCount)),
+    config:set_integer("cluster", "n", NodeCount),
 
     Port = proplists:get_value(port, Options),
     case Port of

--- a/src/setup.erl
+++ b/src/setup.erl
@@ -24,9 +24,9 @@ require_admins(undefined, {undefined, undefined}) ->
 require_admins(_,_) ->
     ok.
 
-require_clustersize(undefined) ->
+require_node_count(undefined) ->
     throw({error, "Cluster setup requires node_count to be configured"});
-require_clustersize(_) ->
+require_node_count(_) ->
     ok.
 
 error_bind_address() ->
@@ -141,7 +141,7 @@ enable_cluster_int(Options, no) ->
     end,
 
     NodeCount = couch_util:get_value(node_count, Options),
-    ok = require_clustersize(NodeCount),
+    ok = require_node_count(NodeCount),
     config:set_integer("cluster", "n", NodeCount),
 
     Port = proplists:get_value(port, Options),

--- a/src/setup_httpd.erl
+++ b/src/setup_httpd.erl
@@ -58,7 +58,8 @@ handle_action("enable_cluster", Setup) ->
         {port, <<"port">>},
         {remote_node, <<"remote_node">>},
         {remote_current_user, <<"remote_current_user">>},
-        {remote_current_password, <<"remote_current_password">>}
+        {remote_current_password, <<"remote_current_password">>},
+        {node_count, <<"node_count">>}
     ], Setup),
     case setup:enable_cluster(Options) of
         {error, cluster_enabled} ->

--- a/test/t-frontend-setup.sh
+++ b/test/t-frontend-setup.sh
@@ -16,10 +16,10 @@ HEADERS="-HContent-Type:application/json"
 curl a:b@127.0.0.1:15986/_nodes/_all_docs
 
 # Enable Cluster on node A
-curl a:b@127.0.0.1:15984/_cluster_setup -d '{"action":"enable_cluster","username":"foo","password":"baz","bind_address":"0.0.0.0"}' $HEADERS
+curl a:b@127.0.0.1:15984/_cluster_setup -d '{"action":"enable_cluster","username":"foo","password":"baz","bind_address":"0.0.0.0","node_count":2}' $HEADERS
 
 # Enable Cluster on node B
-curl a:b@127.0.0.1:15984/_cluster_setup -d '{"action":"enable_cluster","remote_node":"127.0.0.1","port":"25984","remote_current_user":"a","remote_current_password":"b","username":"foo","password":"baz","bind_address":"0.0.0.0"}' $HEADERS
+curl a:b@127.0.0.1:15984/_cluster_setup -d '{"action":"enable_cluster","remote_node":"127.0.0.1","port":"25984","remote_current_user":"a","remote_current_password":"b","username":"foo","password":"baz","bind_address":"0.0.0.0","node_count":2}' $HEADERS
 
 # Add node B on node A
 curl a:b@127.0.0.1:15984/_cluster_setup -d '{"action":"add_node","username":"foo","password":"baz","host":"127.0.0.1","port":25984}' $HEADERS
@@ -56,5 +56,8 @@ curl a:b@127.0.0.1:25984/_users
 curl a:b@127.0.0.1:25984/_replicator
 curl a:b@127.0.0.1:25984/_metadata
 curl a:b@127.0.0.1:25984/_global_changes
+
+# Number of nodes is set to 2
+curl a:b@127.0.0.1:25984/_node/node2@127.0.0.1/_config/cluster/n
 
 echo "YAY ALL GOOD"

--- a/test/t.sh
+++ b/test/t.sh
@@ -16,10 +16,10 @@ HEADERS="-HContent-Type:application/json"
 curl a:b@127.0.0.1:15986/_nodes/_all_docs
 
 # Enable Cluster on node A
-curl a:b@127.0.0.1:15984/_cluster_setup -d '{"action":"enable_cluster","username":"foo","password":"baz","bind_address":"0.0.0.0"}' $HEADERS
+curl a:b@127.0.0.1:15984/_cluster_setup -d '{"action":"enable_cluster","username":"foo","password":"baz","bind_address":"0.0.0.0","node_count":2}' $HEADERS
 
 # Enable Cluster on node B
-curl a:b@127.0.0.1:25984/_cluster_setup -d '{"action":"enable_cluster","username":"foo","password":"baz","bind_address":"0.0.0.0"}' $HEADERS
+curl a:b@127.0.0.1:25984/_cluster_setup -d '{"action":"enable_cluster","username":"foo","password":"baz","bind_address":"0.0.0.0","node_count":2}' $HEADERS
 
 # Add node B on node A
 curl a:b@127.0.0.1:15984/_cluster_setup -d '{"action":"add_node","username":"foo","password":"baz","host":"127.0.0.1","port":25984}' $HEADERS
@@ -56,5 +56,8 @@ curl a:b@127.0.0.1:25984/_users
 curl a:b@127.0.0.1:25984/_replicator
 curl a:b@127.0.0.1:25984/_metadata
 curl a:b@127.0.0.1:25984/_global_changes
+
+# Number of nodes is set to 2
+curl a:b@127.0.0.1:25984/_node/node2@127.0.0.1/_config/cluster/n
 
 echo "YAY ALL GOOD"


### PR DESCRIPTION
when setting up a node, require the nodecount from the user. when
setting up a cluster, they will probably know it, if not the ui
other interfaces can count it easily for them. this will remove
the warning for a non matching nodecount for the user, and it
is easy to implement in uis and cli clients (e.g. a wizard for
fauxton or cli client like nmo).

once clusterwide setup lands this gets obviously superfluous.

COUCHDB-2598

This closes COUCHDB-2594
