### PR TITLE
add_node: Don't fail if node name != "couchdb" or "node1"

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ UI shows an “Add Node” interface with the fields admin, and node:
     },
     "node": {
       "host": "hostname",
-      ["port": 5984]
+      ["port": 5984],
+      "name": "node1"  // as in “node1@hostname”, same as in vm.args
     }
   }
 ```

--- a/src/setup.erl
+++ b/src/setup.erl
@@ -200,13 +200,14 @@ add_node_int(Options, ok) ->
 
     Host = proplists:get_value(host, Options),
     Port = get_port(proplists:get_value(port, Options, 5984)),
+    Name = proplists:get_value(name, Options, get_default_name(Port)),
 
     Url = binary_to_list(<<"http://", Host/binary, ":", Port/binary, "/_cluster_setup">>),
 
     case ibrowse:send_req(Url, Headers, post, Body, RequestOptions) of
         {ok, "201", _, _} ->
             % when done, PUT :5986/nodes/nodeB
-            create_node_doc(Host, Port);
+            create_node_doc(Host, Name);
         Else ->
             couch_log:notice("send_req: ~p~n", [Else]),
             Else
@@ -219,16 +220,15 @@ get_port(Port) when is_list(Port) ->
 get_port(Port) when is_binary(Port) ->
     Port.
 
-create_node_doc(Host, Port) ->
+create_node_doc(Host, Name) ->
     {ok, Db} = couch_db:open_int(<<"_nodes">>, []),
-    Name = get_name(Port),
     Doc = {[{<<"_id">>, <<Name/binary, "@", Host/binary>>}]},
     Options = [],
     CouchDoc = couch_doc:from_json_obj(Doc),
 
     couch_db:update_doc(Db, CouchDoc, Options).
 
-get_name(Port) ->
+get_default_name(Port) ->
     case Port of
         % shortcut for easier development
         <<"15984">> ->

--- a/src/setup_httpd.erl
+++ b/src/setup_httpd.erl
@@ -87,7 +87,8 @@ handle_action("add_node", Setup) ->
         {username, <<"username">>},
         {password, <<"password">>},
         {host, <<"host">>},
-        {port, <<"port">>}
+        {port, <<"port">>},
+        {name, <<"name">>}
     ], Setup),
     case setup:add_node(Options) of
         {error, cluster_not_enabled} ->

--- a/test/t-frontend-setup.sh
+++ b/test/t-frontend-setup.sh
@@ -22,7 +22,7 @@ curl a:b@127.0.0.1:15984/_cluster_setup -d '{"action":"enable_cluster","username
 curl a:b@127.0.0.1:15984/_cluster_setup -d '{"action":"enable_cluster","remote_node":"127.0.0.1","port":"25984","remote_current_user":"a","remote_current_password":"b","username":"foo","password":"baz","bind_address":"0.0.0.0"}' $HEADERS
 
 # Add node B on node A
-curl a:b@127.0.0.1:15984/_cluster_setup -d '{"action":"add_node","username":"foo","password":"baz","host":"127.0.0.1","port":25984}' $HEADERS
+curl a:b@127.0.0.1:15984/_cluster_setup -d '{"action":"add_node","username":"foo","password":"baz","host":"127.0.0.1","port":25984,"name":"node2"}' $HEADERS
 
 # Show cluster state:
 curl a:b@127.0.0.1:15986/_nodes/_all_docs

--- a/test/t.sh
+++ b/test/t.sh
@@ -22,7 +22,7 @@ curl a:b@127.0.0.1:15984/_cluster_setup -d '{"action":"enable_cluster","username
 curl a:b@127.0.0.1:25984/_cluster_setup -d '{"action":"enable_cluster","username":"foo","password":"baz","bind_address":"0.0.0.0"}' $HEADERS
 
 # Add node B on node A
-curl a:b@127.0.0.1:15984/_cluster_setup -d '{"action":"add_node","username":"foo","password":"baz","host":"127.0.0.1","port":25984}' $HEADERS
+curl a:b@127.0.0.1:15984/_cluster_setup -d '{"action":"add_node","username":"foo","password":"baz","host":"127.0.0.1","port":25984,"name":"node2"}' $HEADERS
 
 # Show cluster state:
 curl a:b@127.0.0.1:15986/_nodes/_all_docs


### PR DESCRIPTION
Adding nodes to a cluster fails if the node names (the `name` of `name@hostname` in vm.args) is different from "couchdb". The code currently infers this name from the port: "node1" if 15984, "node2" if 25984, "node3" if 35984, "couchdb" otherwise. No other possibility.

This is not suited for a production set-up, where multiple servers could have different names.

This patch fixes this problem by adding an optional "name" option to the "add_node" command:

```
  POST /_cluster_setup
  {
    "action": "add_node",
    "username": "root",
    "password": "******",
    "host": "production-server.com",
    "port": 5984,
    "name": "node5"
  }
```

This fixes: COUCHDB-3119
