### PR TITLE
fix cluster setup: use same admin pw salt on all nodes

### DIFF
--- a/src/setup_httpd.erl
+++ b/src/setup_httpd.erl
@@ -57,6 +57,7 @@ handle_action("enable_cluster", Setup) ->
     Options = get_options([
         {username, <<"username">>},
         {password, <<"password">>},
+        {password_hash, <<"password_hash">>},
         {bind_address, <<"bind_address">>},
         {port, <<"port">>},
         {remote_node, <<"remote_node">>},


### PR DESCRIPTION
this ensures the same salt on all cluster nodes. before, a session id generated on node1 wouldn’t be valid on node2 and node3. a round-robin haproxy would show a Fauxton login form, and again after login, because the backend node was moved over.

This overrides the hashed password on all secondary nodes with the one from the setup node when the cluster is enabled on the secondary nodes through the setup node.