### PR TITLE
New enable_single_node action, select DBs to create/check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 ebin
 .rebar
+*~
+*.swp

--- a/README.md
+++ b/README.md
@@ -2,21 +2,26 @@ This module implements /_cluster_setup and manages the setting up, duh, of a Cou
 
 ### Testing
 
-```
+```bash
 git clone https://git-wip-us.apache.org/repos/asf/couchdb.git
 cd couchdb
 git checkout setup
 ./configure
 make
-
-# in dev/run comment out the line `connect_nodes("127.0.0.1", 15984)`
-
-dev/run --admin a:b
-
-# in a new terminal
-src/setup/test/t.sh
-
+dev/run --no-join -n 2 --admin a:b
 ```
+
+Then, in a new terminal:
+
+    $ src/setup/test/t.sh
+
+Before running each test, kill the `dev/run` script, then reset the
+CouchDB instances with:
+
+    $ rm -rf dev/lib/ dev/logs/
+    $ dev/run --no-join -n 2 --admin a:b
+
+before running the next shell script.
 
 The Plan:
 

--- a/src/setup.erl
+++ b/src/setup.erl
@@ -208,7 +208,7 @@ enable_single_node(Options) ->
 
     setup_node(NewCredentials, NewBindAddress, 1, Port),
     Dbs = proplists:get_value(ensure_dbs_exist, Options, cluster_system_dbs()),
-    finish_cluster_int(Dbs, has_cluster_system_dbs(Dbs))
+    finish_cluster_int(Dbs, has_cluster_system_dbs(Dbs)),
     couch_log:notice("Enable Single Node: ~p~n", [Options]).
 
 

--- a/src/setup_httpd.erl
+++ b/src/setup_httpd.erl
@@ -94,7 +94,7 @@ handle_action("finish_cluster", Setup) ->
         {error, cluster_finished} ->
             {error, <<"Cluster is already finished">>};
         Else ->
-            couch_log:notice("Else: ~p~n", [Else]),
+            couch_log:notice("finish_cluster: ~p~n", [Else]),
             ok
     end;
 

--- a/src/setup_httpd.erl
+++ b/src/setup_httpd.erl
@@ -39,7 +39,7 @@ handle_setup_req(#httpd{method='GET'}=Req) ->
                 true ->
                     chttpd:send_json(Req, 200, {[{state, single_node_enabled}]})
             end;
-        _ -> 
+        _ ->
             case setup:is_cluster_enabled() of
                 false ->
                     chttpd:send_json(Req, 200, {[{state, cluster_disabled}]});

--- a/src/setup_httpd.erl
+++ b/src/setup_httpd.erl
@@ -32,25 +32,25 @@ handle_setup_req(#httpd{method='GET'}=Req) ->
     Dbs = chttpd:qs_json_value(Req, "ensure_dbs_exist", setup:cluster_system_dbs()),
     couch_log:notice("Dbs: ~p~n", [Dbs]),
     case erlang:list_to_integer(config:get("cluster", "n", undefined)) of
-    1 ->
-        case setup:is_single_node_enabled(Dbs) of
-        no ->
-            chttpd:send_json(Req, 200, {[{state, single_node_disabled}]});
-        ok ->
-            chttpd:send_json(Req, 200, {[{state, single_node_enabled}]})
-        end;
-    _ -> 
-        case setup:is_cluster_enabled() of
-        no ->
-            chttpd:send_json(Req, 200, {[{state, cluster_disabled}]});
-        ok ->
-            case setup:has_cluster_system_dbs(Dbs) of
-            no ->
-                chttpd:send_json(Req, 200, {[{state, cluster_enabled}]});
-            ok ->
-                chttpd:send_json(Req, 200, {[{state, cluster_finished}]})
+        1 ->
+            case setup:is_single_node_enabled(Dbs) of
+                false ->
+                    chttpd:send_json(Req, 200, {[{state, single_node_disabled}]});
+                true ->
+                    chttpd:send_json(Req, 200, {[{state, single_node_enabled}]})
+            end;
+        _ -> 
+            case setup:is_cluster_enabled() of
+                false ->
+                    chttpd:send_json(Req, 200, {[{state, cluster_disabled}]});
+                true ->
+                    case setup:has_cluster_system_dbs(Dbs) of
+                        false ->
+                            chttpd:send_json(Req, 200, {[{state, cluster_enabled}]});
+                        true ->
+                            chttpd:send_json(Req, 200, {[{state, cluster_finished}]})
+                    end
             end
-        end
     end;
 handle_setup_req(#httpd{}=Req) ->
     chttpd:send_method_not_allowed(Req, "GET,POST").

--- a/test/t-single-node.sh
+++ b/test/t-single-node.sh
@@ -1,0 +1,46 @@
+#!/bin/sh -ex
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+HEADERS="-HContent-Type:application/json"
+# show cluster state:
+curl a:b@127.0.0.1:15986/_nodes/_all_docs
+curl a:b@127.0.0.1:15984/_cluster_setup
+
+# Enable Cluster on single node
+curl a:b@127.0.0.1:15984/_cluster_setup -d '{"action":"enable_single_node","username":"foo","password":"baz","bind_address":"127.0.0.1"}' $HEADERS
+
+# Show cluster state:
+curl a:b@127.0.0.1:15986/_nodes/_all_docs
+curl a:b@127.0.0.1:15984/_all_dbs
+curl a:b@127.0.0.1:15984/_cluster_setup
+
+# Delete a database
+curl -X DELETE a:b@127.0.0.1:15984/_global_changes
+
+# Should show single_node_disabled
+curl a:b@127.0.0.1:15984/_cluster_setup
+
+# Change the check
+curl -g 'a:b@127.0.0.1:15984/_cluster_setup?ensure_dbs_exist=["_replicator","_users"]'
+
+# delete all the things
+curl -X DELETE a:b@127.0.0.1:15984/_replicator
+curl -X DELETE a:b@127.0.0.1:15984/_users
+
+# setup only creating _users
+curl -g a:b@127.0.0.1:15984/_cluster_setup -d '{"action":"enable_single_node","username":"foo","password":"baz","bind_address":"127.0.0.1","ensure_dbs_exist":["_users"]}' $HEADERS
+
+# check it
+curl -g 'a:b@127.0.0.1:15984/_cluster_setup?ensure_dbs_exist=["_users"]'
+
+echo "YAY ALL GOOD"


### PR DESCRIPTION
This PR includes two separate features that are related:

* Improve the `/_cluster_setup` endpoint to accept a new `"action": "enable_single_node"` that tolerates binding to 127.0.0.1. It will also set `[cluster] n=1`.
* New parameter `ensure_dbs_exist` for `enable_single_node` and `finish_cluster` actions allows overriding the list of system databases to create. The default remains `["_users", "_replicator", "_global_changes"]`. This parameter can also be specified when doing a `GET /_cluster_setup` and is used for the check if a cluster is completed.

Addresses apache/couchdb#593