### PR TITLE
fix: make sure cluster setups do not exceed n=3 by default

### DIFF
--- a/src/setup.erl
+++ b/src/setup.erl
@@ -169,7 +169,9 @@ setup_node(NewCredentials, NewBindAddress, NodeCount, Port) ->
             config:set("chttpd", "bind_address", binary_to_list(NewBindAddress))
     end,
 
-    config:set_integer("cluster", "n", NodeCount),
+    % for single node setups, set n=1, for larger setups, don’t
+    % exceed n=3 as a default
+    config:set_integer("cluster", "n", min(NodeCount, 3)),
 
     case Port of
         undefined ->


### PR DESCRIPTION
Single node setups want an n=1 setting, but that is the only
time the number of nodes and the number of replicas is linked.

In larger clusters, the values should not be the same. This
patch ensures that for clusters >3 nodes, we do not have to
tell the users to set node_count to 3 in the _cluster_setup
API.

More context for this in https://issues.apache.org/jira/browse/COUCHDB-2594